### PR TITLE
Fetch thrift files we depend on from other projects, use them in scrooge compile

### DIFF
--- a/lein-finagle-clojure/src/leiningen/finagle_clojure.clj
+++ b/lein-finagle-clojure/src/leiningen/finagle_clojure.clj
@@ -20,10 +20,13 @@
   [thrift-code]
   (map second (re-seq #"include \"(.+\.thrift)\"" thrift-code)))
 
+(def ^:private target-temp-dir
+  "target/thrift-include")
+
 (defn- copy-file-to-target-temp-dir
   "Copies a thrift file we depend on into target/thrift-include"
   [project-root ^URL thrift-url filename]
-  (let [target-dir (File. project-root "target/thrift-include")
+  (let [target-dir (File. project-root target-temp-dir)
         target-file (File. target-dir filename)]
     (.mkdirs target-dir)
     (leiningen.core.main/info
@@ -71,7 +74,7 @@
             _ (doseq [filename include-filenames
                       :let [resource (io/resource filename)]]
                 (copy-file-to-target-temp-dir project-root resource filename))
-            include-dir (.getPath (File. project-root "target/thrift-include/"))
+            include-dir (.getPath (File. project-root target-temp-dir))
             scrooge-args (concat ["--finagle" "--skip-unchanged" "--language" "java" "--dest" absolute-dest-path]
                                  ["-i" include-dir]
                                  thrift-files)]


### PR DESCRIPTION
To properly work with this change we need to change our projects to add `src/thrift` to the list of source paths, so all the `.thrift` files are in the classpath. Other than that, this change to the lein-finagle-clojure plugin lets us include thrift files from other projects automagically.

At compile time, the plugin now scrapes the thrift sources for instances of `include "something.thrift"`, resulting in a list of dependency thrift files. It then resolves all those source filenames on the classpath, and then copies all those resources into `target/thrift-include/*.thrift`. Finally, when it goes to call the scrooge compiler, it passes `-i target/thrift-include`, which signals to search there whenever our source files include stuff.
